### PR TITLE
Dev

### DIFF
--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -78,7 +78,7 @@ public class Screenshot extends CordovaPlugin {
         } else {
             //View view = webView.getView();//.getRootView();
             View view = this.cordova.getActivity().getWindow().getDecorView().getRootView();
-            Bitmap bitmap = Bitmap.createBitmap(
+            bitmap = Bitmap.createBitmap(
                 view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888
             );
             Canvas canvas = new Canvas(bitmap);

--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
+import android.graphics.Canvas;
 import android.net.Uri;
 import android.os.Environment;
 import android.util.Base64;
@@ -77,9 +78,12 @@ public class Screenshot extends CordovaPlugin {
         } else {
             //View view = webView.getView();//.getRootView();
             View view = this.cordova.getActivity().getWindow().getDecorView().getRootView();
-            view.setDrawingCacheEnabled(true);
-            bitmap = Bitmap.createBitmap(view.getDrawingCache());
-            view.setDrawingCacheEnabled(false);
+            Bitmap bitmap = Bitmap.createBitmap(
+                view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888
+            );
+            Canvas canvas = new Canvas(bitmap);
+            view.draw(canvas);
+            return bitmap;
         }
 
         return bitmap;

--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -20,6 +20,11 @@ import android.util.Base64;
 import android.view.TextureView;
 import android.view.View;
 import android.view.ViewGroup;
+import android.graphics.Rect;
+import android.os.Handler;
+import android.view.PixelCopy;
+import android.view.View;
+import android.view.Window;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -185,10 +190,39 @@ public class Screenshot extends CordovaPlugin {
         super.cordova.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                Bitmap bitmap = getBitmap();
-                if (bitmap != null) {
-                    getScreenshotAsURI(bitmap, mQuality);
-                }
+//                Bitmap bitmap = getBitmap();
+//                if (bitmap != null) {
+//                    getScreenshotAsURI(bitmap, mQuality);
+//                }
+                    Window window = this.cordova.getActivity().getWindow();
+                    if (window != null) {
+                        View view = this.cordova.getActivity().getWindow().getDecorView().getRootView();
+                        Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888);
+                        int[] locationOfViewInWindow = new int[2];
+                        view.getLocationInWindow(locationOfViewInWindow);
+                        try {
+
+                            PixelCopy.request(
+                                window,
+                                new Rect(
+                                        locationOfViewInWindow[0],
+                                        locationOfViewInWindow[1],
+                                        locationOfViewInWindow[0] + view.getWidth(),
+                                        locationOfViewInWindow[1] + view.getHeight()
+                                ), bitmap, copyResult -> {
+                                    if (copyResult == PixelCopy.SUCCESS) {
+                                        getScreenshotAsURI(bitmap, mQuality);
+                                    } else {
+                                        // Handle other result codes if needed
+                                    }
+                                },
+                                new Handler()
+                            );
+                        } catch (IllegalArgumentException e) {
+                            // PixelCopy may throw IllegalArgumentException, make sure to handle it
+                            e.printStackTrace();
+                        }
+                    }
             }
         });
     }

--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -191,44 +191,37 @@ public class Screenshot extends CordovaPlugin {
         activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-//                Bitmap bitmap = getBitmap();
-//                if (bitmap != null) {
-//                    getScreenshotAsURI(bitmap, mQuality);
-//                }
-                    Window window = activity.getWindow();
-                    if (window != null) {
-                        View view = window.getDecorView().getRootView();
-                        Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888);
-                        int[] locationOfViewInWindow = new int[2];
-                        view.getLocationInWindow(locationOfViewInWindow);
-                        try {
-
-                            PixelCopy.request(
-                                window,
-                                new Rect(
-                                        locationOfViewInWindow[0],
-                                        locationOfViewInWindow[1],
-                                        locationOfViewInWindow[0] + view.getWidth(),
-                                        locationOfViewInWindow[1] + view.getHeight()
-                                ), bitmap, copyResult -> {
-                                    if (copyResult == PixelCopy.SUCCESS) {
-                                        activity.runOnUiThread(new Runnable() {
-                                            @Override
-                                            public void run() {
-                                                getScreenshotAsURI(bitmap, mQuality);
-                                            }
-                                        });
-                                    } else {
-                                        // Handle other result codes if needed
-                                    }
-                                },
-                                new Handler()
-                            );
-                        } catch (IllegalArgumentException e) {
-                            // PixelCopy may throw IllegalArgumentException, make sure to handle it
-                            e.printStackTrace();
-                        }
+                Window window = activity.getWindow();
+                if (window != null) {
+                    View view = window.getDecorView().getRootView();
+                    Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888);
+                    int[] locationOfViewInWindow = new int[2];
+                    view.getLocationInWindow(locationOfViewInWindow);
+                    try {
+                        PixelCopy.request(
+                            window,
+                            new Rect(
+                                locationOfViewInWindow[0],
+                                locationOfViewInWindow[1],
+                                locationOfViewInWindow[0] + view.getWidth(),
+                                locationOfViewInWindow[1] + view.getHeight()
+                            ), bitmap, copyResult -> {
+                                if (copyResult == PixelCopy.SUCCESS) {
+                                    activity.runOnUiThread(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            getScreenshotAsURI(bitmap, mQuality);
+                                        }
+                                    });
+                                }
+                            },
+                            new Handler()
+                        );
+                    } catch (IllegalArgumentException e) {
+                        // PixelCopy may throw IllegalArgumentException, make sure to handle it
+                        e.printStackTrace();
                     }
+                }
             }
         });
     }

--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -25,6 +25,7 @@ import android.os.Handler;
 import android.view.PixelCopy;
 import android.view.View;
 import android.view.Window;
+import android.app.Activity;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -186,17 +187,17 @@ public class Screenshot extends CordovaPlugin {
 
     public void getScreenshotAsURI() throws JSONException{
         mQuality = (Integer) mArgs.get(0);
-
-        super.cordova.getActivity().runOnUiThread(new Runnable() {
+        Activity activity = super.cordova.getActivity();
+        activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
 //                Bitmap bitmap = getBitmap();
 //                if (bitmap != null) {
 //                    getScreenshotAsURI(bitmap, mQuality);
 //                }
-                    Window window = this.cordova.getActivity().getWindow();
+                    Window window = activity.getWindow();
                     if (window != null) {
-                        View view = this.cordova.getActivity().getWindow().getDecorView().getRootView();
+                        View view = window.getDecorView().getRootView();
                         Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888);
                         int[] locationOfViewInWindow = new int[2];
                         view.getLocationInWindow(locationOfViewInWindow);
@@ -211,7 +212,12 @@ public class Screenshot extends CordovaPlugin {
                                         locationOfViewInWindow[1] + view.getHeight()
                                 ), bitmap, copyResult -> {
                                     if (copyResult == PixelCopy.SUCCESS) {
-                                        getScreenshotAsURI(bitmap, mQuality);
+                                        activity.runOnUiThread(new Runnable() {
+                                            @Override
+                                            public void run() {
+                                                getScreenshotAsURI(bitmap, mQuality);
+                                            }
+                                        });
                                     } else {
                                         // Handle other result codes if needed
                                     }

--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -75,7 +75,8 @@ public class Screenshot extends CordovaPlugin {
         if (isCrosswalk) {
             webView.getPluginManager().postMessage("captureXWalkBitmap", this);
         } else {
-            View view = webView.getView();//.getRootView();
+            //View view = webView.getView();//.getRootView();
+            View view = this.cordova.getActivity().getWindow().getDecorView().getRootView();
             view.setDrawingCacheEnabled(true);
             bitmap = Bitmap.createBitmap(view.getDrawingCache());
             view.setDrawingCacheEnabled(false);
@@ -190,7 +191,7 @@ public class Screenshot extends CordovaPlugin {
 
      public void getScreenshotAsURISync() throws JSONException{
         mQuality = (Integer) mArgs.get(0);
-        
+
         Runnable r = new Runnable(){
             @Override
             public void run() {


### PR DESCRIPTION
**Problem** 
Video screenshots are not getting captured, appear as black screen.

**Cause**
Bitmap computation logic fails for video
Currently it is done like this

            View view = webView.getView();//.getRootView();
            view.setDrawingCacheEnabled(true);
            bitmap = Bitmap.createBitmap(view.getDrawingCache());
            view.setDrawingCacheEnabled(false);
Two problem in this -

view.getDrawingCache() is deprecated from API 28
it fails to capture bitmap for video as they are not cached
**Fix** 
Updated getScreenshotAsURI() method of cordova-screenshot plugin
Changing bitmap computation logic.
I have used [PixelCopy API](https://developer.android.com/reference/android/view/PixelCopy) to get the bitmap.